### PR TITLE
Fix release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ for i in "${buckets[@]}"; do
 	aws s3api delete-bucket --bucket "$i"
 done
 ```
+
+## Testing release process
+
+To run goreleaser locally to test changes to the release process configuration:
+
+    goreleaser release --snapshot --skip-publish --rm-dist

--- a/dummy.go
+++ b/dummy.go
@@ -1,3 +1,5 @@
+// +build neverbuild
+
 package main
 
 func main() {


### PR DESCRIPTION
use a build tag to force dummy.go to be excluded from the goreleaser build.