### PR TITLE
one more goreleaser fix

### DIFF
--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -21,6 +21,9 @@ jobs:
         uses: ngalaiko/bazel-action/1.2.1@master
         with:
           args: run :install
+      - name: clean working tree
+        run: |
+          git checkout -- version.bzl
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@master
         env:


### PR DESCRIPTION
goreleaser refuses to run with a dirty working tree, so reset version.bzl after the bazel build before running goreleaser.
