### PR TITLE
fix release publication workflow with bazelisk

### DIFF
--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -12,6 +12,10 @@ jobs:
         uses: actions/setup-go@master
         with:
           go-version: 1.14
+      - name: Install bazelisk
+        run: |
+          sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64
+          sudo chmod +x /usr/local/bin/bazel
       - name: Check out code
         uses: actions/checkout@master
       - name: stamp version
@@ -19,9 +23,7 @@ jobs:
           export VERSION=$(echo $GITHUB_REF|sed 's/refs\/tags\/v//')
           echo "VERSION = '$VERSION'" > version.bzl
       - name: bazel build darwin
-        uses: ngalaiko/bazel-action/1.2.1@master
-        with:
-          args: run :install
+        run : bazel run :install
       - name: clean working tree
         run: |
           git checkout -- version.bzl


### PR DESCRIPTION
release publication was failing with the old bazel action, switch to installing bazelisk same as we do in the CI workflow.