### PR TITLE
Revert "use bot app auth rather than personal access token (#221)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,18 +18,10 @@ jobs:
         run: |
           sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64
           sudo chmod +x /usr/local/bin/bazel
-      # this is tibdex/github-app-token v1.5.1, pinned to the commit SHA for security
-      - uses: tibdex/github-app-token@7ce9ffdcdeb2ba82b01b51d6584a6a85872336d4
-        id: generate-token
-        with:
-          app_id: ${{ secrets.AUTH_FOR_GITHUB_APP_ID }}
-          private_key: ${{ secrets.AUTH_FOR_GITHUB_PRIVATE_KEY }}
-        if: (github.actor == 'dependabot-preview[bot]') || (github.actor == 'renovate[bot]')
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
-          # lets see if this works without the custom token
-          # token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
       - name: Sync Dependencies
         run: bazel run //:vendor
@@ -38,10 +30,9 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4.13.0
         with:
           commit_message: Apply syncdeps changes
-          commit_user_name: kindlymachine[bot]
           branch: ${{ github.head_ref }}
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
         if: (github.actor == 'dependabot-preview[bot]') || (github.actor == 'renovate[bot]')
       - name: bazel build
         run: bazel run :install
@@ -68,7 +59,7 @@ jobs:
       - name: dry run goreleaser
         uses: goreleaser/goreleaser-action@v2
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
         with:
           version: latest
           args: release --snapshot --skip-publish

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,7 +79,7 @@ scoop:
   # Git author used to commit to the repository.
   # Defaults are shown.
   commit_author:
-    name: kindlymachine[bot]
+    name: support-kindlyops
     email: support@kindlyops.com
 
   # Your app's homepage.


### PR DESCRIPTION
This reverts commit 4c724cf54e5d99d64350ff4315f0a94f068b2753.

We must use a GitHub PAT in order for the syncdeps autocommit
generated during the workflow processing a dependency update
to trigger a new workflow run.