### PR TITLE
adjustments for amd64_v1 suffix since go 1.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.17.2
+          go-version: 1.18.5
       - name: setup-syft
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \

--- a/goreleaser-post-hook.sh
+++ b/goreleaser-post-hook.sh
@@ -2,14 +2,14 @@
 set -eo pipefail
 
 echo "moving bazel outputs to goreleaser dist directory for packaging..."
-mkdir -p dist/deleterious_darwin_amd64
+mkdir -p dist/deleterious_darwin_amd64_v1
 mkdir -p dist/deleterious_darwin_arm64
-mkdir -p dist/deleterious_linux_amd64
+mkdir -p dist/deleterious_linux_amd64_v1
 mkdir -p dist/deleterious_linux_arm64
-mkdir -p dist/deleterious_windows_amd64
+mkdir -p dist/deleterious_windows_amd64_v1
 
-sudo cp -f bdist/deleterious-darwin dist/deleterious_darwin_amd64/deleterious
+sudo cp -f bdist/deleterious-darwin dist/deleterious_darwin_amd64_v1/deleterious
 sudo cp -f bdist/deleterious-darwin-m1 dist/deleterious_darwin_arm64/deleterious
-sudo cp -f bdist/deleterious-linux dist/deleterious_linux_amd64/deleterious
+sudo cp -f bdist/deleterious-linux dist/deleterious_linux_amd64_v1/deleterious
 sudo cp -f bdist/deleterious-linux-arm dist/deleterious_linux_arm64/deleterious
-sudo cp -f bdist/deleterious-windows.exe dist/deleterious_windows_amd64/deleterious.exe
+sudo cp -f bdist/deleterious-windows.exe dist/deleterious_windows_amd64_v1/deleterious.exe


### PR DESCRIPTION
Per https://goreleaser.com/customization/build/#why-is-there-a-_v1-suffix-on-amd64-builds
> Why is there a _v1 suffix on amd64 builds?[¶](https://goreleaser.com/customization/build/#why-is-there-a-_v1-suffix-on-amd64-builds)
Go 1.18 introduced the GOAMD64 option, and v1 is the default value for that option.

> Since you can have GoReleaser build for multiple different GOAMD64 targets, it adds that suffix to prevent name conflicts. The same thing happens for arm and GOARM, mips and GOMIPS and others.